### PR TITLE
bugfix/MYS-138: Timezone fix for form validation, ensure our ssc_comm…

### DIFF
--- a/patches/core-tz_alter.patch
+++ b/patches/core-tz_alter.patch
@@ -7,7 +7,7 @@ index deba8f16a0..eb6e3bfcb6 100644
    }
 
 +  // Allow modules to alter this list. But can't modify when submitting.
-+  if (!isset($_POST['op'])) {
++  if (!isset($_POST['op']) || isset($_POST['form_id'])) {
 +    $zones = \Drupal::moduleHandler()->invokeAll('timezone_list_alter', [$zones]);
 +  }
 +


### PR DESCRIPTION
…on hook_timezone_list_alter is working for form validation, adjusted core patch for framework.