### PR TITLE
SERVGOVT-294 and DRUF-48 - Fix calendar_link regression, add patch fo…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -270,6 +270,9 @@
             "drupal/bg_image_formatter": {
                 "3254830 - add parent entity id token": "https://www.drupal.org/files/issues/2021-12-17/entity_id_token-3254830-6.patch"
             },
+            "drupal/calendar_link": {
+                "3392784 - Fix WSOD if date is string": "https://www.drupal.org/files/issues/2024-12-06/3392784-20.patch"
+            },
             "drupal/content_sync": {
                 "2979368 - ignore types": "https://www.drupal.org/files/issues/2020-09-22/2979368-17.patch"
             },


### PR DESCRIPTION
Fix calendar_link regression, add patch for issue 3392784 that fixes WSOD.

NOTE: the calendar_link module also requires a fairly recent patch release of PHP 8.1 to work properly when using Drupal 10.3, tested 8.1.22+ as working fine with Drupal 10.3, Drupal 10.2 was not affected the same way.