### PR TITLE
Fix ssc_common JS dependency import

### DIFF
--- a/modules/common/ssc_common/js/global.js
+++ b/modules/common/ssc_common/js/global.js
@@ -1,89 +1,21 @@
-(function ($, Drupal, cookies) {
-  Drupal.behaviors.ssc_common = {};
-  var init = false;
+(function ($, Drupal, once, cookies) {
+  "use strict";
 
-  Drupal.behaviors.ssc_common.attach = function (context, settings) {
-    // Improve Session fieldset labels on Event edit form - NOTE: needs to run after Ajax "remove" button
-    $('[id^="edit-field-sessions"] > [data-drupal-selector^="edit-field-sessions-widget"]').each((function() {
-      var date = $(this).find('input.form-date').attr('value');
-      var lang = $(this).find('div.field--name-field-session-language select option:selected').text();
-      $(this).find('summary').first().html(date + " - " + lang);
-    }));
-
-    if (init) {
-      return;
-    }
-    init = true;
-
-    // Add IDs for TOC H2/H3
-    var level1 = 0;
-    var level2 = 0;
-    $('h2, h3', '.toc-section').each(function() {
-      // Only add ID when there is no parent element with the .toc-ignore class
-      if ($(this).parents('.toc-ignore').length === 0) {
-        var id = $(this).attr('id');
-
-        if ($(this).prop('tagName') === 'H2') {
-          level1++;
-          level2 = 0;
+  Drupal.behaviors.sscCommon = {};
+  Drupal.behaviors.sscCommon.attach = function (context, settings) {
+    once('ssc-common', document.documentElement, context).forEach(function () {
+      // Override jQuery UI dialog string to become translatable
+      $.widget("ui.dialog", $.ui.dialog, {
+        options: {
+          closeText: Drupal.t("Close")
         }
-        else {
-          level2++;
-        }
+      });
 
-        if (id) {
-          $(this).attr('id', `${id}-01`);
-        }
-        else {
-          $(this).attr('id', `section-${level1}-${level2}`);
-        }
-      }
+      // Fix Cancel button on VBO confirmation pages (required on Bootstrap only)
+      $("form.views-bulk-operations-confirm-action button#edit-cancel").attr(
+        "name",
+        "op"
+      );
     });
-
-    function setDateFilter(date) {
-      $('input#edit-date-min--2').val(date);
-      $('input#edit-date-max--2').val(date);
-      $('.landing-page .views-exposed-form button[id^="edit-submit"]').click();
-    }
-
-    // Hack to fix Reset button not clearing filters on Events page.
-    $('.landing-page .views-exposed-form button[id^="edit-reset"]').click(function() {
-      setDateFilter(null);
-      $('.landing-page .views-exposed-form input.form-checkbox').prop('checked', false);
-      $('.landing-page .views-exposed-form input.form-text').prop('value', '');
-      $('.landing-page .views-exposed-form select').prop('value', 'All');
-
-      // Clear Query on lang switcher
-      $("#user-profile-block-switcher a")[0].search = "";
-    });
-
-    $("a.ics-link").each(function() {
-      var href = $(this).attr('href');
-      href = href.replace("text/calendar", "data:text/calendar");
-      $(this).attr('href', href);
-    });
-
-    // Hide Country selector on Custom address for Session - painful to do with CSS
-    $('#node-event-form label:contains("Country")').parent().hide();
-  };
-
-  // Set last dashboard tab
-  $('li.tabs__tab').click(function() {
-    cookies.set('dashboard_tab', $(this).find('a').attr('id'));
-  });
-
-  // Move Node form buttons to bottom of Meta group
-  $('form.node-form #edit-meta').append($('#edit-actions'));
-
-  // Add form-required to Campaign Date
-  $('.field--name-field-campaign-date .fieldset__label').addClass('form-required');
-  $('.field--name-field-campaign-date h4.form-item__label:contains("Start")').addClass('form-required');
-
-  // Override jQuery UI dialog string to become translatable
-  $.widget("ui.dialog", $.ui.dialog, {
-    options: {
-      closeText: Drupal.t("Close")
-    }
-  });
-
-})(jQuery, Drupal, window.Cookies);
+  }
+})(jQuery, Drupal, once, window.Cookies);

--- a/themes/common/ssc_admin/js/global.js
+++ b/themes/common/ssc_admin/js/global.js
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Addional global interactivity.
+ */
+
+(function ($, Drupal, once) {
+  "use strict";
+
+  Drupal.behaviors.sscAdmin = {};
+  Drupal.behaviors.sscAdmin.attach = function (context, settings) {
+    // Improve Session fieldset labels on Event edit form - NOTE: needs to re-run after Ajax
+    $('[id^="edit-field-sessions"] > [data-drupal-selector^="edit-field-sessions-widget"]').each((function () {
+      const date = $(this).find('input.form-date').attr('value');
+      const lang = $(this).find('div.field--name-field-session-language select option:selected').text();
+      $(this).find('summary').first().html(date + " - " + lang);
+    }));
+
+    once('ssc-admin', document.documentElement, context).forEach(function () {
+      // Hide Country selector on custom address for Session - painful to do with CSS
+      $('#node-event-form label:contains("Country")').parent().hide();
+
+      // Add form-required to Campaign Date
+      $('.field--name-field-campaign-date .fieldset__label').addClass('form-required');
+      $('.field--name-field-campaign-date h4.form-item__label:contains("Start")').addClass('form-required');
+      
+      // Move Node form buttons to bottom of Meta group
+      $('form.node-form #edit-meta').append($('#edit-actions'));
+    });
+  }
+})(jQuery, Drupal, once);

--- a/themes/common/ssc_admin/ssc_admin.libraries.yml
+++ b/themes/common/ssc_admin/ssc_admin.libraries.yml
@@ -4,3 +4,5 @@ global:
       css/admin.css: {}
       css/forms.css: {}
       css/tables.css: {}
+  js:
+    js/global.js: {}

--- a/themes/common/ssc_base/js/global.js
+++ b/themes/common/ssc_base/js/global.js
@@ -3,49 +3,77 @@
  * Addional global interactivity.
  */
 
-(function ($, Drupal) {
+(function ($, Drupal, once) {
   "use strict";
 
-  Drupal.behaviors.sscBaseScript = {};
-  Drupal.behaviors.sscBaseScript.attach = function (context, settings) {
-    // Delete empty IDs in Slick Slider (causing HTML validation errors)
-    $(".slick-cloned").each(function () {
-      this.removeAttribute("id");
-    });
+  Drupal.behaviors.sscBase = {};
+  Drupal.behaviors.sscBase.attach = function (context, settings) {
+    once('ssc-base', document.documentElement, context).forEach(function () {
+      // Add IDs for TOC H2/H3
+      let level1 = 0;
+      let level2 = 0;
+      $('h2, h3', '.toc-section').each(function() {
+        // Only add ID when there is no parent element with the .toc-ignore class
+        if ($(this).parents('.toc-ignore').length === 0) {
+          const id = $(this).attr('id');
 
-    // Set <details> elements to automatically open on print if their <summary> contains a heading
-    $('details', '.section-main').each(function () {
-      const detailsEl = this;
-      const hasHeading = $('summary', detailsEl).find('h2, h3, h4, h5, h6').length > 0;
+          if ($(this).prop('tagName') === 'H2') {
+            level1++;
+            level2 = 0;
+          }
+          else {
+            level2++;
+          }
 
-      if (hasHeading) {
-        // Open <details> when the print modal shows up
-        $(window).on('beforeprint', function () {
-          $(detailsEl).attr('open', '');
-        });
+          if (id) {
+            $(this).attr('id', `${id}-01`);
+          }
+          else {
+            $(this).attr('id', `section-${level1}-${level2}`);
+          }
+        }
+      });
 
-        // Close <details> when the print modal is dismissed
-        $(window).on('afterprint', function () {
-          $(detailsEl).removeAttr('open');
-        });
-      }
-    });
+      // Delete empty IDs in Slick Slider (causing HTML validation errors)
+      $(".slick-cloned").each(function () {
+        this.removeAttribute("id");
+      });
 
-    // Add stretched link class to search teasers
-    $(".search-result a").addClass("stretched-link");
+      // Set <details> elements to automatically open on print if their <summary> contains a heading
+      $('details', '.section-main').each(function () {
+        const detailsEl = this;
+        const hasHeading = $('summary', detailsEl).find('h2, h3, h4, h5, h6').length > 0;
 
-    // Re-adds stretched link class after an AJAX search form submission
-    $(document).ajaxComplete(function () {
+        if (hasHeading) {
+          // Open <details> when the print modal shows up
+          $(window).on('beforeprint', function () {
+            $(detailsEl).attr('open', '');
+          });
+
+          // Close <details> when the print modal is dismissed
+          $(window).on('afterprint', function () {
+            $(detailsEl).removeAttr('open');
+          });
+        }
+      });
+
+      // Add stretched link class to search teasers
       $(".search-result a").addClass("stretched-link");
+
+      // Re-adds stretched link class after an AJAX search form submission
+      $(document).ajaxComplete(function () {
+        $(".search-result a").addClass("stretched-link");
+      });
+
+      // Add stretched link class to upcoming events teasers on the News landing page
+      $(".upcoming-event a").addClass("stretched-link");
+
+      // Fix ICS links on Event pages
+      $("a.ics-link").each(function() {
+        let href = $(this).attr('href');
+        href = href.replace("text/calendar", "data:text/calendar");
+        $(this).attr('href', href);
+      });
     });
-
-    // Add stretched link class to upcoming events teasers on the News landing page
-    $(".upcoming-event a").addClass("stretched-link");
-
-    // Fix Cancel button on VBO confirmation pages (required on Bootstrap only)
-    $("form.views-bulk-operations-confirm-action button#edit-cancel").attr(
-      "name",
-      "op"
-    );
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/themes/common/ssc_base/ssc_base.libraries.yml
+++ b/themes/common/ssc_base/ssc_base.libraries.yml
@@ -56,7 +56,6 @@ global:
     - core/drupal
     - core/drupalSettings
     - core/drupal.dialog.ajax
-    - ssc_common/global
 
 entity_moderation_form:
   css:


### PR DESCRIPTION
- Remove ssc_common/global as a dependency in the base theme
- Isolate theme-specific JS logic into dedicate global.js files
- Add missing once() function calls to avoid re-runs