### PR TITLE
DRUF-70 - core/js-cookie becomes js_cookie/js-cookie since Drupal 10.3.0.

### DIFF
--- a/modules/common/ssc_common/ssc_common.libraries.yml
+++ b/modules/common/ssc_common/ssc_common.libraries.yml
@@ -5,7 +5,7 @@ global:
     - core/jquery
     - core/drupalSettings
     - core/drupal
-    - core/js-cookie
+    - js_cookie/js-cookie
 
 site:
   js:


### PR DESCRIPTION
…3.0.