### PR TITLE
Add html id attribute to teaser cards

### DIFF
--- a/themes/common/ssc_base/components/card-teaser/card-teaser.twig
+++ b/themes/common/ssc_base/components/card-teaser/card-teaser.twig
@@ -1,7 +1,7 @@
 {% set classes = ['card', 'card-teaser'] %}
 
 <div class="card-container">
-  <article class="{{ classes|join(' ') }}" data-card-id="{{ id }}" data-card-variant="{{ variant ? variant : 'regular' }}">
+  <article class="{{ classes|join(' ') }}" data-card-id="{{ id }}" id="{{ id }}" data-card-variant="{{ variant ? variant : 'regular' }}">
     {% if is_external %}
       <div class="card__external" aria-hidden="true">
         <svg viewbox="0 0 35 35">


### PR DESCRIPTION
This is needed to exclude these items from Adobe Analytics click tracking